### PR TITLE
Correct way of Registering Service Provider for the Dependency.

### DIFF
--- a/src/Jakubsacha/Adminlte/AdminlteServiceProvider.php
+++ b/src/Jakubsacha/Adminlte/AdminlteServiceProvider.php
@@ -45,10 +45,17 @@ class AdminlteServiceProvider extends ServiceProvider {
         $this->app->register('Thomaswelton\LaravelGravatar\LaravelGravatarServiceProvider');
 
         /*
-         * Create alias for the dependency.
+         * Create alias for the dependency if its not already created.
          */
-        $loader = \Illuminate\Foundation\AliasLoader::getInstance();
-        $loader->alias('Gravatar', '\Thomaswelton\LaravelGravatar\Facades\Gravatar');
+        $this->app->booting(function(){
+            $loader = \Illuminate\Foundation\AliasLoader::getInstance();
+            $aliases = \Config::get('app.aliases');
+
+            // Alias the Gravatar package
+            if (empty($aliases['Gravatar'])) {
+                $loader->alias('Gravatar', 'Thomaswelton\LaravelGravatar\Facades\Gravatar');
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Due to the previous method used, it ends up throwing the follow error:

```
strtolower() expects parameter 1 to be string, array given (View: .../vendor/jakubsacha/adminlte/src/views/layouts/dashboard/header.blade.php) (View: .../vendor/jakubsacha/adminlte/src/views/layouts/dashboard/header.blade.php) (View: .../vendor/jakubsacha/adminlte/src/views/layouts/dashboard/header.blade.php) 
```

With this PR, That fixes this bug.
